### PR TITLE
Streamline install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ And the python libraries, preferably in your virtualenv:
 
 Finally, install `smoke`:
 
-    pip install git+https://github.com/skadistats/smoke#master
+    pip install git+https://github.com/bwarren2/smoke#master
 
 That's it! You're good to go.
 

--- a/README.md
+++ b/README.md
@@ -90,22 +90,14 @@ In Ubuntu, you might install dependencies thusly:
 
 And the python libraries, preferably in your virtualenv:
 
-    $ pip install cython # http://bit.ly/1dd0JRI for problems with virtualenv
-    $ pip install palm
-    $ pip install python-snappy
+    pip install cython python-snappy git+https://github.com/bumptech/palm#master
 
-Next, you must install `palm` 0.1.9 from source--it's not in PyPI, so you can't
-get it with pip:
+Finally, install `smoke`:
 
-    $ git clone https://github.com/bumptech/palm.git && cd palm
-    $ python setup.py install
-
-Finally, install `smoke` by cloning it:
-
-    $ git clone https://github.com/skadistats/smoke.git && cd smoke
-    $ python setup.py install
+    pip install git+https://github.com/skadistats/smoke#master
 
 That's it! You're good to go.
+
 
 
 # Hacking

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Finally, install `smoke`:
 That's it! You're good to go.
 
 
-
 # Hacking
 
 If you want to hack on smoke, you might consider doing this instead of the

--- a/dota2.proto
+++ b/dota2.proto
@@ -969,6 +969,12 @@ enum EDotaUserMessages {
 	DOTA_UM_PlayerMMR = 126;
 	DOTA_UM_AbilitySteal = 127;
 	DOTA_UM_CourierKilledAlert = 128;
+	DOTA_UM_EnemyItemAlert = 129;
+	DOTA_UM_StatsMatchDetails = 130;
+	DOTA_UM_MiniTaunt = 131;
+	DOTA_UM_BuyBackStateAlert = 132;
+	DOTA_UM_QuickBuyAlert = 133;
+	DOTA_UM_StatsHeroDetails = 134;
 }
 
 enum DOTA_CHAT_MESSAGE {


### PR DESCRIPTION
I tried to boil down the linux install instructions to a two-liner and remove the duplicate palm install.  This worked in my toy venv, but outside confirmation would be useful too.  When I figure out how to import cythonize after dependencies are installed, this can get down to a one-liner.
